### PR TITLE
Fix spurious installation warning

### DIFF
--- a/lineInstall.m
+++ b/lineInstall.m
@@ -24,7 +24,7 @@ if ~any(strcmp('Parallel Computing Toolbox', {v.Name}))
     warning('The Parallel Computing Toolbox is not installed, this is required for LINE.')
     hasWarnings = true;
 end
-if ~any(strcmp('Symbolic Math Toolbox ', {v.Name}))
+if ~any(strcmp('Symbolic Math Toolbox', {v.Name}))
     warning('The Symbolic Math Toolbox is not installed, this may be required by some LINE methods.')
     hasWarnings = true;
 end


### PR DESCRIPTION
Fix spurious installation warning claiming that MATLAB's "Symbolic Math Toolbox" isn't installed even if it is.

The bug was caused by the fact that when searching for the toolbox name in the output of the `ver` command to assess whether the toolbox is installed, a trailing blank space was included in the string to match (i.e. the toolbox name). This commit removes the trailing blank space.